### PR TITLE
[VMAF] Coarsely ported to MSVC x86

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 dist/
 vmaf_output.xml
 compile_commands.json
+.vscode/

--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -49,8 +49,23 @@ if not cc.check_header('stdatomic.h')
     endif
 endif
 
+# to compile with msvc, we need to bring in a POSIX translation layer
+posix_dependency = []
+if cc.get_id() == 'msvc'
+    posix_dependency = declare_dependency(
+        include_directories : include_directories('src/compat/discord_win'),
+    )
+endif
+
+# instead of quirking to MSVC in code, guard with a specific flag for easier auditing
+if cc.get_id() == 'msvc'
+    add_global_arguments('-DDISCORD_WINDOWS_PORT', language: 'c')
+endif
+
 subdir('include')
 subdir('src')
-subdir('tools')
+if cc.get_id() != 'msvc'
+    subdir('tools')
+endif
 subdir('doc')
 subdir('test')

--- a/libvmaf/src/compat/discord_win/pthread.h
+++ b/libvmaf/src/compat/discord_win/pthread.h
@@ -1,0 +1,37 @@
+#ifndef __PTHREAD_H
+#define __PTHREAD_H
+
+// TODO: these are very quick and dirty. Notably, _beginthreadex has troubling semantics for its return value
+
+#include <windows.h>
+#include <process.h>
+
+// Mutexes
+typedef CRITICAL_SECTION pthread_mutex_t;
+#define pthread_mutex_init(a, b) 0; InitializeCriticalSection(a)
+#define pthread_mutex_lock(a) EnterCriticalSection(a)
+#define pthread_mutex_unlock(a) LeaveCriticalSection(a)
+#define pthread_mutex_destroy(a) DeleteCriticalSection(a)
+
+// Condition Variables
+typedef CONDITION_VARIABLE pthread_cond_t;
+#define pthread_cond_init(a, b) 0; InitializeConditionVariable(a)
+#define pthread_cond_wait(a, b) SleepConditionVariableCS(a, b, INFINITE)
+#define pthread_cond_signal(a) WakeConditionVariable(a)
+#define pthread_cond_broadcast(a) WakeAllConditionVariable(a)
+#define pthread_cond_destroy(a) /*no-op in windows*/
+
+// Thread Creation
+typedef HANDLE pthread_t;
+#define pthread_create(a, b, c, d) *a = (HANDLE) _beginthreadex(NULL, 0, c, d, 0, NULL)
+#define pthread_join(a, b) WaitForSingleObject(a, INFINITE)
+#define pthread_detach(a) CloseHandle(a)
+
+/*
+typedef HANDLE pthread_t;
+#define pthread_create(a, b, c, d) *a = 0
+#define pthread_join(a, b) 
+#define pthread_detach(a) 
+*/
+
+#endif

--- a/libvmaf/src/compat/discord_win/unistd.h
+++ b/libvmaf/src/compat/discord_win/unistd.h
@@ -1,0 +1,10 @@
+#ifndef _UNISTD_H
+#define _UNISTD_H
+
+#include <stdlib.h>
+#include <io.h>
+
+#define fileno _fileno
+#define isatty _isatty
+
+#endif

--- a/libvmaf/src/compat/msvc/stdatomic.h
+++ b/libvmaf/src/compat/msvc/stdatomic.h
@@ -39,7 +39,10 @@
 
 #include <windows.h>
 
+// Unconvinced that this code compiles, but marking for now
+#ifndef DISCORD_WINDOWS_PORT
 #include "common/attributes.h"
+#endif
 
 typedef volatile LONG  __declspec(align(32)) atomic_int;
 typedef volatile ULONG __declspec(align(32)) atomic_uint;

--- a/libvmaf/src/feature/adm.c
+++ b/libvmaf/src/feature/adm.c
@@ -49,7 +49,9 @@ static char *init_dwt_band(adm_dwt_band_t *band, char *data_top, size_t buf_sz_o
     return data_top;
 }
 
+#ifndef DISCORD_WINDOWS_PORT
 __attribute__((unused))
+#endif
 static char *init_dwt_band_d(adm_dwt_band_t_d *band, char *data_top, size_t buf_sz_one)
 {
     band->band_a = (double *)data_top; data_top += buf_sz_one;

--- a/libvmaf/src/feature/ciede.c
+++ b/libvmaf/src/feature/ciede.c
@@ -43,6 +43,9 @@ SOFTWARE.
 */
 
 #include <errno.h>
+#ifdef DISCORD_WINDOWS_PORT
+#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include <stddef.h>
 #include <string.h>

--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -22,6 +22,8 @@
 #include "feature_extractor.h"
 #include "feature_name.h"
 #include "integer_adm.h"
+// TODO: need __builtin_clz from:
+#include "integer_vif.h"
 #include "log.h"
 
 #if ARCH_X86

--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -643,7 +643,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     const size_t data_sz =
         2 * (pad_size + frame_size + pad_size) + 2 * (h * s->public.buf.stride_16) +
         5 * (s->public.buf.stride_32) + 7 * s->public.buf.stride_tmp;
-    void *data = aligned_malloc(data_sz, MAX_ALIGN);
+    char *data = aligned_malloc(data_sz, MAX_ALIGN);
     if (!data) return -ENOMEM;
     memset(data, 0, data_sz);
 

--- a/libvmaf/src/feature/integer_vif.h
+++ b/libvmaf/src/feature/integer_vif.h
@@ -130,6 +130,35 @@ VifResiduals vif_compute_line_residuals(VifPublicState *s, unsigned from,
 #ifdef _MSC_VER
 #include <intrin.h>
 
+#ifdef DISCORD_WINDOWS_PORT
+static inline int custom_clz(unsigned long long x) {
+    // Our build is 32-bit, so 64-bit versions aren't available
+    if (x == 0) {
+        return 64;
+    }
+
+    int n = 0;
+    for (int i = 63; i >= 0; i--) {
+        if ((x & (unsigned __int64)(1ULL << i)) == 0) {
+            n++;
+        }
+        else {
+            break;
+        }
+    }
+
+    return n;
+}
+
+static inline int __builtin_clz(unsigned x) {
+    return custom_clz(x);
+}
+
+static inline int __builtin_clzll(unsigned long long x) {
+    return custom_clz(x);
+}
+
+#else // DISCORD_WINDOWS_PORT
 static inline int __builtin_clz(unsigned x) {
     return (int)__lzcnt(x);
 }
@@ -137,6 +166,8 @@ static inline int __builtin_clz(unsigned x) {
 static inline int __builtin_clzll(unsigned long long x) {
     return (int)__lzcnt64(x);
 }
+
+#endif
 
 #endif
 

--- a/libvmaf/src/feature/integer_vif.h
+++ b/libvmaf/src/feature/integer_vif.h
@@ -131,34 +131,20 @@ VifResiduals vif_compute_line_residuals(VifPublicState *s, unsigned from,
 #include <intrin.h>
 
 #ifdef DISCORD_WINDOWS_PORT
-static inline int custom_clz(unsigned long long x) {
-    // Our build is 32-bit, so 64-bit versions aren't available
-    if (x == 0) {
-        return 64;
-    }
-
-    int n = 0;
-    for (int i = 63; i >= 0; i--) {
-        if ((x & (unsigned __int64)(1ULL << i)) == 0) {
-            n++;
-        }
-        else {
-            break;
-        }
-    }
-
-    return n;
-}
-
 static inline int __builtin_clz(unsigned x) {
-    return custom_clz(x);
+    unsigned long out = 0;
+    if (x == 0 || !_BitScanReverse(&out, x)) return 32;
+    return 31 - out;
 }
 
 static inline int __builtin_clzll(unsigned long long x) {
-    return custom_clz(x);
+    if (x <= UINT32_MAX) return 32 + __builtin_clz((unsigned)x);
+    return __builtin_clz(x >> 32u);
 }
 
 #else // DISCORD_WINDOWS_PORT
+// Note that these implementations assume a hardware instruction is available, otherwise they will be wrong
+// TODO: consider using the Discord variants universally
 static inline int __builtin_clz(unsigned x) {
     return (int)__lzcnt(x);
 }

--- a/libvmaf/src/feature/mkdirp.h
+++ b/libvmaf/src/feature/mkdirp.h
@@ -12,6 +12,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#ifdef DISCORD_WINDOWS_PORT
+#define mode_t int
+#endif
+
 /*
  * Recursively `mkdir(path, mode)`
  */

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -855,7 +855,8 @@ int vmaf_score_pooled_model_collection(VmafContext *vmaf,
     const char *suffix_stddev = "_stddev";
     const size_t name_sz =
         strlen(model_collection->name) + strlen(suffix_lo) + 1;
-    char name[name_sz];
+    char* name = malloc(name_sz);
+    if (!name) return -ENOMEM;
     memset(name, 0, name_sz);
 
     snprintf(name, name_sz, "%s%s", model_collection->name, suffix_bagging);
@@ -878,6 +879,7 @@ int vmaf_score_pooled_model_collection(VmafContext *vmaf,
                                      &score->bootstrap.ci.p95.hi,
                                      index_low, index_high);
 
+    free(name);
     return err;
 }
 

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -364,7 +364,8 @@ if is_cuda_enabled
     common_cuda_objects += cuda_static_lib.extract_all_objects()
 endif
 
-thread_lib = dependency('threads')
+threads_impl_lib = dependency('threads')
+thread_lib = declare_dependency(dependencies: [threads_impl_lib, posix_dependency])
 math_lib = cc.find_library('m', required : false)
 
 vmaf_include = include_directories(
@@ -439,7 +440,7 @@ libvmaf_feature_static_lib = static_library(
     'libvmaf_feature',
     libvmaf_feature_sources,
     include_directories : [libvmaf_include, vmaf_include, cuda_dir],
-    dependencies: [stdatomic_dependency, cuda_dependency],
+    dependencies: [posix_dependency, stdatomic_dependency, cuda_dependency],
     objects: common_cuda_objects
 )
 

--- a/libvmaf/src/thread_pool.c
+++ b/libvmaf/src/thread_pool.c
@@ -92,6 +92,16 @@ static void *vmaf_thread_pool_runner(void *p)
     return NULL;
 }
 
+#ifdef DISCORD_WINDOWS_PORT
+static unsigned __stdcall vmaf_thread_pool_runner_windows_adapter(void *p) {
+    vmaf_thread_pool_runner(p);
+    return 0;
+}
+#define THREAD_FN vmaf_thread_pool_runner_windows_adapter
+#else
+#define THREAD_FN vmaf_thread_pool_runner
+#endif
+
 int vmaf_thread_pool_create(VmafThreadPool **pool, unsigned n_threads)
 {
     if (!pool) return -EINVAL;
@@ -108,7 +118,7 @@ int vmaf_thread_pool_create(VmafThreadPool **pool, unsigned n_threads)
 
     for (unsigned i = 0; i < n_threads; i++) {
         pthread_t thread;
-        pthread_create(&thread, NULL, vmaf_thread_pool_runner, p);
+        pthread_create(&thread, NULL, THREAD_FN, p);
         pthread_detach(thread);
     }
 

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -21,12 +21,13 @@ test_feature_collector = executable('test_feature_collector',
     ['test.c', 'test_feature_collector.c', '../src/log.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/feature/'), include_directories('../src')],
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
-    dependencies: cuda_dependency
+    dependencies: [cuda_dependency, thread_lib]
 )
 
 test_log = executable('test_log',
     ['test.c', 'test_log.c', '../src/log.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
+    dependencies: posix_dependency
 )
 
 test_thread_pool = executable('test_thread_pool',
@@ -41,7 +42,7 @@ test_model = executable('test_model',
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
     c_args : [vmaf_cflags_common, '-DJSON_MODEL_PATH="'+join_paths(meson.project_source_root(), '../model/')+'"'],
     cpp_args : vmaf_cflags_common,
-    dependencies : [thread_lib, cuda_dependency],
+    dependencies : [stdatomic_dependency, thread_lib, cuda_dependency],
 )
 
 test_predict = executable('test_predict',
@@ -52,14 +53,14 @@ test_predict = executable('test_predict',
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
-    dependencies : [thread_lib, cuda_dependency],
+    dependencies : [stdatomic_dependency, thread_lib, cuda_dependency],
 )
 
 test_feature_extractor = executable('test_feature_extractor',
     ['test.c', 'test_feature_extractor.c', '../src/mem.c', '../src/picture.c', '../src/ref.c',
      '../src/dict.c', '../src/opt.c', '../src/log.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
-    dependencies : [math_lib, stdatomic_dependency, cuda_dependency],
+    dependencies : [math_lib, posix_dependency, stdatomic_dependency, cuda_dependency],
     objects : [
       common_cuda_objects,
       platform_specific_cpu_objects,
@@ -82,6 +83,7 @@ test_cpu = executable('test_cpu',
 test_ref = executable('test_ref',
     ['test.c', 'test_ref.c', '../src/ref.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
+    dependencies: stdatomic_dependency
 )
 
 test_feature = executable('test_feature',
@@ -93,14 +95,14 @@ test_ciede = executable('test_ciede',
     ['test.c', 'test_ciede.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
-    dependencies: cuda_dependency
+    dependencies: [posix_dependency, stdatomic_dependency, cuda_dependency]
 )
 
 test_cambi = executable('test_cambi',
     ['test.c', 'test_cambi.c', '../src/picture.c', '../src/mem.c', '../src/ref.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
-    dependencies: cuda_dependency
+    dependencies: [posix_dependency, stdatomic_dependency, cuda_dependency]
 )
 
 test_luminance_tools = executable('test_luminance_tools',

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -234,8 +234,9 @@ static char *test_decimate_generic()
 
 static char *test_filter_mode()
 {
+#define w 5
     VmafPicture filtered_image, image;
-    unsigned w = 5, h = 5;
+    unsigned h = 5;
     uint16_t buffer[3 * w];
 
     int err = vmaf_picture_alloc(&filtered_image, VMAF_PIX_FMT_YUV400P, 10, w, h);
@@ -279,6 +280,7 @@ static char *test_filter_mode()
     vmaf_picture_unref(&filtered_image);
 
     return NULL;
+#undef w
 }
 
 static char *test_get_mask_index()

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -54,9 +54,9 @@ static char *test_get_feature_extractor_by_name_and_feature_name()
 
 static char *test_feature_extractor_context_pool()
 {
+#define n_threads 8
     int err = 0;
 
-    const unsigned n_threads = 8;
     VmafFeatureExtractorContextPool *pool;
     err = vmaf_fex_ctx_pool_create(&pool, n_threads);
     mu_assert("problem during vmaf_fex_ctx_pool_create", !err);
@@ -82,6 +82,7 @@ static char *test_feature_extractor_context_pool()
     mu_assert("problem during vmaf_fex_ctx_pool_destroy", !err);
 
     return NULL;
+#undef n_threads
 }
 
 static char *test_feature_extractor_flush()


### PR DESCRIPTION
This is an initial iteration of building VMAF on a 32-bit x86 system using the Visual Studio C compiler

- Introduced the preproccessor variable `DISCORD_WINDOWS_PORT` as a catch-all for cases where something was done specifically for MSVC or building for x86.
- Added a tiny POSIX compatibility layer, including for pthread functions. This is very incomplete, has corner cases, and is for evaluation purposes only.
- Removed cases of variable sized arrays, as MSVC does not support them.