### PR TITLE
[VMAF] Enabled AVX et al. detection on 32 bit systems

### DIFF
--- a/libvmaf/src/x86/cpuid.asm
+++ b/libvmaf/src/x86/cpuid.asm
@@ -44,11 +44,10 @@ cglobal cpu_cpuid, 0, 5, 0, regs, leaf, subleaf
 %endif
     RET
 
-cglobal cpu_xgetbv, 0, 0, 0, xcr
+cglobal cpu_xgetbv, 0, 4, 0, regs, xcr
+    mov        r3, regsmp
     movifnidn ecx, xcrm
     xgetbv
-%if ARCH_X86_64
-    shl       rdx, 32
-    or        rax, rdx
-%endif
+    mov  [r3+4*0], eax
+    mov  [r3+4*1], edx
     RET

--- a/libvmaf/src/x86/cpuid.asm
+++ b/libvmaf/src/x86/cpuid.asm
@@ -44,10 +44,10 @@ cglobal cpu_cpuid, 0, 5, 0, regs, leaf, subleaf
 %endif
     RET
 
-cglobal cpu_xgetbv, 0, 4, 0, regs, xcr
-    mov        r3, regsmp
+cglobal cpu_xgetbv, 0, 5, 0, regs, xcr
+    mov        r4, regsmp
     movifnidn ecx, xcrm
     xgetbv
-    mov  [r3+4*0], eax
-    mov  [r3+4*1], edx
+    mov  [r4+4*0], eax
+    mov  [r4+4*1], edx
     RET


### PR DESCRIPTION
These CPU extensions can work on x86 systems and do not need to be gated behind 64-bit availability