### PR TITLE
[VMAF] Improved the pthread shim used on Windows

### DIFF
--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -51,18 +51,25 @@ endif
 
 # to compile with msvc, we need to bring in a POSIX translation layer
 posix_dependency = []
-if cc.get_id() == 'msvc'
-    posix_dependency = declare_dependency(
-        include_directories : include_directories('src/compat/discord_win'),
-    )
-endif
 
 if get_option('enable_discord_mode') == true
     add_global_arguments('-DDISCORD_PORT', language: 'c')
     # instead of quirking to MSVC in code, guard with a specific flag for easier auditing
     if cc.get_id() == 'msvc'
         add_global_arguments('-DDISCORD_WINDOWS_PORT', language: 'c')
+        pthread_shim_library = static_library(
+            'pthread_shim_library',
+            ['./src/compat/discord_win/pthread.c'],
+        )
+        posix_dependency = declare_dependency(
+            link_with: pthread_shim_library,
+            include_directories : include_directories('src/compat/discord_win'),
+        )
     endif
+elif cc.get_id() == 'msvc'
+    posix_dependency = declare_dependency(
+        include_directories : include_directories('src/compat/discord_win'),
+    )
 endif
 
 subdir('include')

--- a/libvmaf/src/compat/discord_win/pthread.c
+++ b/libvmaf/src/compat/discord_win/pthread.c
@@ -1,0 +1,118 @@
+#include "pthread.h"
+
+#include <stdlib.h>
+
+typedef struct {
+    void* (*startFn)(void*);
+    void *args;
+} ThreadState;
+
+#define EINVAL 22
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const void* mustBeUnused) {
+    if (mustBeUnused) {
+        return EINVAL;
+    }
+
+    InitializeCriticalSection(mutex);
+    return 0;
+}
+
+int pthread_mutex_lock(pthread_mutex_t* mutex) {
+    EnterCriticalSection(mutex);
+    return 0;
+}
+
+int pthread_mutex_unlock(pthread_mutex_t* mutex) {
+    LeaveCriticalSection(mutex);
+    return 0;
+}
+
+int pthread_mutex_destroy(pthread_mutex_t* mutex) {
+    DeleteCriticalSection(mutex);
+    return 0;
+}
+
+int pthread_cond_init(pthread_cond_t* cond, const void* mustBeUnused) {
+    if (mustBeUnused) {
+        return EINVAL;
+    }
+
+    InitializeConditionVariable(cond);
+    return 0;
+}
+
+int pthread_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex) {
+    BOOL ret = SleepConditionVariableCS(cond, mutex, INFINITE);
+    if (ret == 0) {
+        // If the function succeeds, the return value is nonzero.
+        return EINVAL;
+    }
+
+    return 0;
+}
+
+int pthread_cond_signal(pthread_cond_t* cond) {
+    WakeConditionVariable(cond);
+    return 0;
+}
+
+int pthread_cond_broadcast(pthread_cond_t* cond) {
+    WakeAllConditionVariable(cond);
+    return 0;
+}
+
+int pthread_cond_destroy(pthread_cond_t* cond) {
+    (void)cond; // Not needed with *ConditionVariable API
+    return 0;
+}
+
+static unsigned __stdcall begin_thread_to_pthread(void* in) {
+    ThreadState* threadState = (ThreadState*)(in);
+
+    threadState->startFn(threadState->args);
+
+    free(threadState);
+    return 0;
+}
+
+int pthread_create(pthread_t* thread, void* mustBeUnused, void* (*startFn)(void*), void* arg) {
+    if (mustBeUnused || !thread) {
+        return EINVAL;
+    }
+
+    ThreadState* threadState = (ThreadState*)(malloc(sizeof(ThreadState)));
+    if (threadState == NULL) {
+        return EINVAL;
+    }
+
+    threadState->args = arg;
+    threadState->startFn = startFn;
+
+    // Begin suspended to handle a case where _beginthreadex can execute the thread before returning
+    uintptr_t ret = _beginthreadex(NULL, 0, begin_thread_to_pthread, threadState, CREATE_SUSPENDED, NULL);
+    if (ret == 0) {
+        // "On an error, _beginthreadex returns 0, and errno and _doserrno are set"
+        free(threadState);
+        return EINVAL;
+    }
+    HANDLE handle = (HANDLE)(ret);
+    // If the return value of ResumeThread is 1, the specified thread was suspended but was restarted. 
+    if (ResumeThread(handle) != 1) {
+        // ... so, since the thread was started suspended, it should be started, and any other return value is a failure
+        // TODO: intentionally leaking the malloc as the documentation of ResumeThread is ambiguous if the thread can still run in the presence of failures to ResumeThread
+        return EINVAL;
+    }
+    *thread = handle;
+    return 0;
+}
+
+int pthread_detach(pthread_t thread) {
+    // Note that CloseHandle of a thread can race process destruction--you can end up with the thread exiting after main returns/when parts of the runtime have already been torn down, and crash.
+    BOOL ret = CloseHandle(thread);
+    if (ret == 0) {
+        return EINVAL;
+    }
+
+    return 0;
+}

--- a/libvmaf/src/compat/discord_win/pthread.h
+++ b/libvmaf/src/compat/discord_win/pthread.h
@@ -1,37 +1,23 @@
 #ifndef __PTHREAD_H
 #define __PTHREAD_H
 
-// TODO: these are very quick and dirty. Notably, _beginthreadex has troubling semantics for its return value
-
 #include <windows.h>
 #include <process.h>
 
-// Mutexes
 typedef CRITICAL_SECTION pthread_mutex_t;
-#define pthread_mutex_init(a, b) 0; InitializeCriticalSection(a)
-#define pthread_mutex_lock(a) EnterCriticalSection(a)
-#define pthread_mutex_unlock(a) LeaveCriticalSection(a)
-#define pthread_mutex_destroy(a) DeleteCriticalSection(a)
-
-// Condition Variables
 typedef CONDITION_VARIABLE pthread_cond_t;
-#define pthread_cond_init(a, b) 0; InitializeConditionVariable(a)
-#define pthread_cond_wait(a, b) SleepConditionVariableCS(a, b, INFINITE)
-#define pthread_cond_signal(a) WakeConditionVariable(a)
-#define pthread_cond_broadcast(a) WakeAllConditionVariable(a)
-#define pthread_cond_destroy(a) /*no-op in windows*/
-
-// Thread Creation
 typedef HANDLE pthread_t;
-#define pthread_create(a, b, c, d) *a = (HANDLE) _beginthreadex(NULL, 0, c, d, 0, NULL)
-#define pthread_join(a, b) WaitForSingleObject(a, INFINITE)
-#define pthread_detach(a) CloseHandle(a)
 
-/*
-typedef HANDLE pthread_t;
-#define pthread_create(a, b, c, d) *a = 0
-#define pthread_join(a, b) 
-#define pthread_detach(a) 
-*/
+int pthread_mutex_init(pthread_mutex_t* mutex, const void* mustBeUnused);
+int pthread_mutex_lock(pthread_mutex_t* mutex);
+int pthread_mutex_unlock(pthread_mutex_t* mutex);
+int pthread_mutex_destroy(pthread_mutex_t* mutex);
+int pthread_cond_init(pthread_cond_t* cond, const void* mustBeUnused);
+int pthread_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex);
+int pthread_cond_signal(pthread_cond_t* cond);
+int pthread_cond_broadcast(pthread_cond_t* cond);
+int pthread_cond_destroy(pthread_cond_t* cond);
+int pthread_create(pthread_t* thread, void* mustBeUnused, void* (*startFn)(void*), void* arg);
+int pthread_detach(pthread_t thread);
 
 #endif

--- a/libvmaf/src/thread_pool.c
+++ b/libvmaf/src/thread_pool.c
@@ -92,16 +92,6 @@ static void *vmaf_thread_pool_runner(void *p)
     return NULL;
 }
 
-#ifdef DISCORD_WINDOWS_PORT
-static unsigned __stdcall vmaf_thread_pool_runner_windows_adapter(void *p) {
-    vmaf_thread_pool_runner(p);
-    return 0;
-}
-#define THREAD_FN vmaf_thread_pool_runner_windows_adapter
-#else
-#define THREAD_FN vmaf_thread_pool_runner
-#endif
-
 int vmaf_thread_pool_create(VmafThreadPool **pool, unsigned n_threads)
 {
     if (!pool) return -EINVAL;
@@ -118,7 +108,7 @@ int vmaf_thread_pool_create(VmafThreadPool **pool, unsigned n_threads)
 
     for (unsigned i = 0; i < n_threads; i++) {
         pthread_t thread;
-        pthread_create(&thread, NULL, THREAD_FN, p);
+        pthread_create(&thread, NULL, vmaf_thread_pool_runner, p);
         pthread_detach(thread);
     }
 


### PR DESCRIPTION
This replaces the very problematic `#define`-based pthread replacement with a much-less-but-still-problematic C implementation.

- Since they are functions, this fixes bugs in the `#define`s that didn't "return" values for a few functions
- Allows state to exist, so that we don't have to quirk the callback signature for `pthread_create`
- Notably does **not** implement the entire surface area of functions. They will emit failures if certain arguments (unused by VMAF) are used.
- Biggest remaining issue with this implementation is if a thread is started, detached, and the process exits soon after, you can hit some UB (read: crash) related to not joining the thread and it executing after important things are destroyed via `main` exit