### PR TITLE
[VMAF] fix leak on integer_motion close

### DIFF
--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -269,6 +269,13 @@ static int extract_force_zero(VmafFeatureExtractor *fex,
     return err;
 }
 
+static int close_force_zero(VmafFeatureExtractor *fex)
+{
+    MotionState *s = fex->priv;
+
+    return vmaf_dictionary_free(&s->feature_name_dict);
+}
+
 static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
@@ -285,7 +292,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     if (s->motion_force_zero) {
         fex->extract = extract_force_zero;
         fex->flush = NULL;
-        fex->close = NULL;
+        fex->close = close_force_zero;
         return 0;
     }
 


### PR DESCRIPTION
Failing to call a `close` function means that `feature_name_dict` and its contents are never freed.